### PR TITLE
Downgrade mxml version to 2.0.4 and related metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 About mxml-feedstock
 ====================
 
+**The package name for mxml was changed to zeem starting from version 2.0.5.**
+**Please use zeem instead of mxml if you use mxml with the version more than v2.0.4.**
+
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/mxml-feedstock/blob/main/LICENSE.txt)
 
 Home: https://mhekkel.github.io/zeem

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,8 +1,8 @@
 context:
   name: mxml
-  version: "2.0.5"
-  sha256: cf82135e85c856e700ecaeb0a046769c84827166e6218b34839bf06301466e6f
-  build_number: 0
+  version: "2.0.4"
+  sha256: 06e1ff2ee662b250162e5510cb5f7ddee6ce2eb4a42b9e267f0f22ca7b857f7c
+  build_number: 1
 
 package:
   name: ${{ name }}
@@ -55,17 +55,17 @@ tests:
   - script:
       - if: unix
         then:
-          - test -d ${PREFIX}/include/zeem
-          - test -f ${PREFIX}/lib/libzeem${SHLIB_EXT}
+          - test -d ${PREFIX}/include/mxml
+          - test -f ${PREFIX}/lib/libmxml${SHLIB_EXT}
         else:
-          - if not exist "%LIBRARY_PREFIX%\include\zeem\" exit /b 1
-          - if not exist "%LIBRARY_PREFIX%\lib\zeem.lib" exit /b 1
-          - if not exist "%LIBRARY_PREFIX%\bin\zeem.dll" exit /b 1
+          - if not exist "%LIBRARY_PREFIX%\include\mxml\" exit /b 1
+          - if not exist "%LIBRARY_PREFIX%\lib\mxml.lib" exit /b 1
+          - if not exist "%LIBRARY_PREFIX%\bin\mxml.dll" exit /b 1
 
 about:
-  homepage: https://mhekkel.github.io/zeem
-  repository: https://github.com/mhekkel/zeem
-  documentation: https://mhekkel.github.io/zeem
+  homepage: https://mhekkel.github.io/mxml
+  repository: https://github.com/mhekkel/mxml
+  documentation: https://mhekkel.github.io/mxml
   license: BSD-2-Clause
   license_file: LICENSE
   summary: "A C++ Module Library offering a full XML library with validating parser, DOM tree, XPaths and serialization."
@@ -79,7 +79,7 @@ about:
 
     This XML library was extracted from [libzeep](https://github.com/mhekkel/libzeep) since having a separate and simple XML library is more convenient.
     The API is unfortunately no longer compatible since the goal was to be more standards compliant.
-    E.g., zeem::element should now be a complete [Sequence Container](https://en.cppreference.com/w/cpp/named_req/SequenceContainer).
+    E.g., mxml::element should now be a complete [Sequence Container](https://en.cppreference.com/w/cpp/named_req/SequenceContainer).
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
**The package name for mxml was changed to zeem starting from version 2.0.5.**

This pull request primarily updates the `mxml` recipe to correct package metadata, test paths, and documentation references. The changes ensure that the recipe consistently refers to `mxml` (instead of the previously incorrect `zeem`) and reverts the version to 2.0.4 with the appropriate checksum.

**Package metadata and version corrections:**

* Reverted the `mxml` package version from "2.0.5" to "2.0.4" and updated the corresponding SHA256 checksum and build number in `recipe.yaml`.
* Updated all homepage, repository, and documentation URLs in the `about` section to point to the correct `mxml` project instead of `zeem`.

**Test and documentation fixes:**

* Fixed test script paths and filenames to use `mxml` instead of `zeem` for both Unix and Windows environments, ensuring the tests validate the correct package installation.
* Updated the documentation string to reference `mxml::element` rather than `zeem::element` to accurately describe the API.

---

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
