### PR TITLE
Alter `run_exports` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 About mxml-feedstock
 ====================
 
-**The package name for mxml was changed to zeem starting from version 2.0.5.**
-**Please use [zeem](https://mhekkel.github.io/zeem) instead of mxml if you use mxml with the version more than v2.0.4.**
-
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/mxml-feedstock/blob/main/LICENSE.txt)
 
 Home: https://mhekkel.github.io/mxml

--- a/README.md
+++ b/README.md
@@ -1,24 +1,21 @@
 About mxml-feedstock
 ====================
 
-**The package name for mxml was changed to zeem starting from version 2.0.5.**
-**Please use [zeem](https://mhekkel.github.io/zeem) instead of mxml if you use mxml with the version more than v2.0.4.**
-
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/mxml-feedstock/blob/main/LICENSE.txt)
 
-Home: https://mhekkel.github.io/zeem
+Home: https://mhekkel.github.io/mxml
 
 Package license: BSD-2-Clause
 
 Summary: A C++ Module Library offering a full XML library with validating parser, DOM tree, XPaths and serialization.
 
-Development: https://github.com/mhekkel/zeem
+Development: https://github.com/mhekkel/mxml
 
-Documentation: https://mhekkel.github.io/zeem
+Documentation: https://mhekkel.github.io/mxml
 
 This is a feature complete XML library containing a validating parser as well as a modern C++ API for the data structures. It also supports serializing custom data structures.
 The core of this library is a validating XML parser with DTD processing and all. On top of this are implemented an API for manipulating XML data in a DOM like fashion and a serialization API. As a bonus there’s also an XPath implementation, albeit this is limited to XPath 1.0.
-This XML library was extracted from [libzeep](https://github.com/mhekkel/libzeep) since having a separate and simple XML library is more convenient. The API is unfortunately no longer compatible since the goal was to be more standards compliant. E.g., zeem::element should now be a complete [Sequence Container](https://en.cppreference.com/w/cpp/named_req/SequenceContainer).
+This XML library was extracted from [libzeep](https://github.com/mhekkel/libzeep) since having a separate and simple XML library is more convenient. The API is unfortunately no longer compatible since the goal was to be more standards compliant. E.g., mxml::element should now be a complete [Sequence Container](https://en.cppreference.com/w/cpp/named_req/SequenceContainer).
 
 Current build status
 ====================

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ About mxml-feedstock
 ====================
 
 **The package name for mxml was changed to zeem starting from version 2.0.5.**
-**Please use zeem instead of mxml if you use mxml with the version more than v2.0.4.**
+**Please use [zeem](https://mhekkel.github.io/zeem) instead of mxml if you use mxml with the version more than v2.0.4.**
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/mxml-feedstock/blob/main/LICENSE.txt)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 About mxml-feedstock
 ====================
 
+**The package name for mxml was changed to zeem starting from version 2.0.5.**
+**Please use [zeem](https://mhekkel.github.io/zeem) instead of mxml if you use mxml with the version more than v2.0.4.**
+
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/mxml-feedstock/blob/main/LICENSE.txt)
 
 Home: https://mhekkel.github.io/mxml

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,7 +2,7 @@ context:
   name: mxml
   version: "2.0.4"
   sha256: 06e1ff2ee662b250162e5510cb5f7ddee6ce2eb4a42b9e267f0f22ca7b857f7c
-  build_number: 1
+  build_number: 2
 
 package:
   name: ${{ name }}

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -21,7 +21,7 @@ build:
         - export CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
         - cmake -S . -B build ${CMAKE_ARGS} -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=ON
         - cmake --build build --config Release --parallel ${CPU_COUNT}
-        # - ctest -V --test-dir build
+        - ctest -V -C Release --test-dir build
         - cmake --install build
       else:
         - echo on
@@ -49,7 +49,7 @@ requirements:
     - fast_float
     - howardhinnant_date
   run_exports:
-    - ${{ pin_subpackage(name|lower, upper_bound="x") }}
+    - ${{ pin_subpackage(name|lower, upper_bound="x.x.x") }}
 
 tests:
   - script:


### PR DESCRIPTION
This pull request updates the `recipe.yaml` for the `mxml` package, mainly to improve build reproducibility and test coverage, as well as to adjust version pinning for downstream dependencies. The most important changes are as follows:

**Build and Testing Improvements:**
* The build number was incremented from 1 to 2 to reflect the updated recipe and ensure new builds are distinguishable.
* The test command was updated to run `ctest` in Release mode, improving test accuracy for production builds.

**Dependency Version Pinning:**
* The `run_exports` pinning was changed from `x` to `x.x.x`, making downstream dependency version constraints more precise and reducing the risk of ABI incompatibilities.

---

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
